### PR TITLE
feat(bottom-tab): added the correct icon and highlight functionnalities

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,5 +1,7 @@
 import { Tabs } from 'expo-router';
 import TabHeader from '../../components/TabHeader';
+import { Focus, List, Wallet } from 'lucide-react-native';
+import { View } from 'react-native';
 
 export default function TabLayout() {
   return (
@@ -9,6 +11,9 @@ export default function TabLayout() {
         options={{
           title: 'Cards',
           headerTitle: () => <TabHeader title="Cards" displayBackButton={false} />,
+          tabBarIcon: ({ focused }) => <List color={focused ? 'black' : '#A09CAB'} size={24} />,
+          tabBarActiveTintColor: 'black',
+          tabBarInactiveTintColor: '#A09CAB',
         }}
       />
       <Tabs.Screen
@@ -16,6 +21,22 @@ export default function TabLayout() {
         options={{
           title: 'Scan',
           headerTitle: () => <TabHeader title="Scan" displayBackButton />,
+          headerShown: false,
+          tabBarLabelStyle: { display: 'none' },
+          tabBarIcon: ({ focused }) => (
+            <View
+              style={{
+                width: 80,
+                height: 80,
+                justifyContent: 'center',
+                alignItems: 'center',
+                borderRadius: 60,
+                backgroundColor: '#EFF1F5',
+              }}
+            >
+              <Focus color={focused ? 'black' : '#A09CAB'} size={40} />
+            </View>
+          ),
         }}
       />
       <Tabs.Screen
@@ -23,6 +44,9 @@ export default function TabLayout() {
         options={{
           title: 'Folio',
           headerTitle: () => <TabHeader title="Folio" displayBackButton />,
+          tabBarIcon: ({ focused }) => <Wallet color={focused ? 'black' : '#A09CAB'} size={24} />,
+          tabBarActiveTintColor: 'black',
+          tabBarInactiveTintColor: '#A09CAB',
         }}
       />
     </Tabs>

--- a/src/app/(tabs)/scan.tsx
+++ b/src/app/(tabs)/scan.tsx
@@ -1,22 +1,5 @@
-import { Text, StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import CardScanner from '../../features/scan/screens/CardScanner';
 
 export default function Scan() {
-  return (
-    <SafeAreaView style={styles.container}>
-      <Text style={styles.text}>Scanner screen</Text>
-    </SafeAreaView>
-  );
+  return <CardScanner />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#25292e',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  text: {
-    color: '#fff',
-  },
-});

--- a/src/features/scan/screens/CardScanner.tsx
+++ b/src/features/scan/screens/CardScanner.tsx
@@ -1,0 +1,35 @@
+import { Text, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Camera, useCameraDevice, useCameraPermission } from 'react-native-vision-camera';
+
+export default function CardScanner() {
+  const { hasPermission, requestPermission } = useCameraPermission();
+  const device = useCameraDevice('back');
+
+  if (hasPermission === false) {
+    requestPermission();
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.text}>Camera permission is required to use this feature.</Text>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      {device && <Camera style={StyleSheet.absoluteFill} device={device} isActive={true} />}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'black',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: '#fff',
+  },
+});


### PR DESCRIPTION
## 📝 Description

Added the correct icons and behavior for the bottom tab bar + the scan screen is now using the correct screen without a header. 

Related task : [FOL-44](https://sleeved.atlassian.net/browse/FOL-44)

## 📸 Screenshots / Demo

![Simulator Screenshot - iPhone 16 Pro - 2025-06-07 at 21 02 17](https://github.com/user-attachments/assets/afb84572-4b3c-4ebe-aed4-efe82e0c2618)

Scan Screen has no header 
![Simulator Screenshot - iPhone 16 Pro - 2025-06-07 at 21 02 19](https://github.com/user-attachments/assets/7fb23490-c055-425b-ab86-f821de554db7)

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-44]: https://sleeved.atlassian.net/browse/FOL-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ