### PR TITLE
feat(folio): integrate folio initialization in email verification process

### DIFF
--- a/src/features/auth/hooks/mutations/useVerifyEmailCode.ts
+++ b/src/features/auth/hooks/mutations/useVerifyEmailCode.ts
@@ -4,6 +4,7 @@ import { AuthResponse } from '../../types';
 import { useRouter } from 'expo-router';
 import { useAuth } from '../../context/AuthContext';
 import { authUtils } from '../../utils/auth-utils';
+import { useInitFolio } from '../../../folio/hooks/mutations/useInitFolio';
 
 interface VerifyEmailPayload {
   email: string;
@@ -13,6 +14,7 @@ interface VerifyEmailPayload {
 export const useVerifyEmailCode = () => {
   const router = useRouter();
   const { setIsAuthenticated, setPendingVerificationEmail } = useAuth();
+  const { mutateAsync: initFolio } = useInitFolio();
 
   return useMutation({
     mutationFn: async ({ email, code }: VerifyEmailPayload) => {
@@ -25,15 +27,20 @@ export const useVerifyEmailCode = () => {
     },
 
     onSuccess: async (response) => {
-      if (response.token) {
-        await authUtils.setToken(response.token);
-        setIsAuthenticated(true);
-        setPendingVerificationEmail(null);
-
-        router.replace('/');
-      } else {
-        console.warn('useVerifyEmail: No token received in verification response');
+      if (!response.token) {
+        throw new Error('Verification failed: No token received');
       }
+      await authUtils.setToken(response.token);
+      setIsAuthenticated(true);
+      setPendingVerificationEmail(null);
+
+      try {
+        await initFolio();
+      } catch (error) {
+        console.error('Failed to initialize folio:', error);
+      }
+
+      router.replace('/');
     },
 
     onError: (error) => {

--- a/src/features/folio/hooks/mutations/useInitFolio.ts
+++ b/src/features/folio/hooks/mutations/useInitFolio.ts
@@ -1,0 +1,22 @@
+import { Alert } from 'react-native';
+import { useMutation } from '@tanstack/react-query';
+import { httpClient } from '../../../../lib/client/http-client';
+
+interface InitFolioResponse {
+  success: boolean;
+  message?: string;
+  folioId?: string;
+}
+
+export const useInitFolio = () => {
+  return useMutation({
+    mutationFn: async () => {
+      const response = await httpClient.post<InitFolioResponse>('/folios/init', {});
+      return response;
+    },
+    onError: () => {
+      Alert.alert('Error', 'Failed to initialize folio. Please try again later.');
+      console.error('Failed to initialize folio');
+    },
+  });
+};


### PR DESCRIPTION
## 📝 Description

Pour qu’un user soit connu dans Atlas, il faut qu’il ait un main folio pour qu’il puisse enregistrer des cartes dans sa collection. Pour faire on fait un POST /init, une fois que l'inscription de l'utilisateur a bien été vérifié.

Related task : [FOL-94](https://sleeved.atlassian.net/browse/FOL-94)

## 📸 Screenshots / Demo

<img width="1046" alt="Capture d’écran 2025-06-25 à 22 12 29" src="https://github.com/user-attachments/assets/01488593-4a1d-49c3-b8f6-0a4e7b11f817" />


## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-94]: https://sleeved.atlassian.net/browse/FOL-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ