### PR TITLE
feat(card-detail): initial occurrence for add card button logic

### DIFF
--- a/src/features/cards/components/AddCardButton.tsx
+++ b/src/features/cards/components/AddCardButton.tsx
@@ -34,6 +34,12 @@ export default function AddCardButton({
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
+  // Initialize quantity and max quantity state based on initialQuantity prop
+  useEffect(() => {
+    setQuantity(Math.min(initialQuantity ?? 0, MAX_QUANTITY));
+    setIsMaxQuantity((initialQuantity ?? 0) >= MAX_QUANTITY);
+  }, [initialQuantity]);
+
   // Clear interval helper
   const clearLongPressTimer = useCallback(() => {
     if (longPressTimerRef.current) {

--- a/src/features/cards/screens/CardDetail.tsx
+++ b/src/features/cards/screens/CardDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useCardDetail } from '../hooks/queries/useCardDetail';
 import { useCardFolioDelete } from '../../folio/hooks/mutations/useCardFolioDelete';
@@ -15,6 +15,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 import { useTheme } from '../../../theme/useTheme';
 import AddCardButton from '../components/AddCardButton';
 import { useCardFolioCollect } from '../../folio/hooks/mutations/useCardFolioCollect';
+import { useRefetchOnFocus } from '../../../hooks/useRefetchOnFocus';
 
 type TabType = 'details' | 'prices';
 
@@ -32,7 +33,16 @@ export default function CardDetail({ cardId }: { cardId: string }) {
     data: basicCardData,
     isLoading: isLoadingBasic,
     error: basicError,
+    refetch: refetchCardDetail,
   } = useCardDetail(cardId as string);
+
+  const [previousCardQuantity, setPreviousCardQuantity] = useState<number>(0);
+
+  useEffect(() => {
+    setPreviousCardQuantity(basicCardData?.occurrence ?? 0);
+  }, [cardId, basicCardData?.occurrence]);
+
+  useRefetchOnFocus(refetchCardDetail);
 
   const tabOptions: TabOption<TabType>[] = [
     { id: 'details', label: 'Details' },
@@ -41,21 +51,27 @@ export default function CardDetail({ cardId }: { cardId: string }) {
 
   const handleCollectionChange = React.useCallback(
     (cardId: string, quantity?: number) => {
+      if (quantity === undefined) return;
+
       switch (true) {
         case quantity === 0:
           deleteCardFolio({ cardId });
           break;
-        case quantity === 1:
+        case quantity === 1 && previousCardQuantity === 0:
+          // POST only when transitioning from 0 to 1
           collectCard({ cardId });
           break;
-        case quantity !== undefined && quantity > 1:
+        case quantity >= 1:
+          // PATCH for all other quantity changes
           updateCardFolio({ cardId, occurrence: quantity });
           break;
         default:
           break;
       }
+
+      setPreviousCardQuantity(quantity);
     },
-    [deleteCardFolio, collectCard, updateCardFolio]
+    [deleteCardFolio, collectCard, updateCardFolio, previousCardQuantity]
   );
 
   if (isLoadingBasic) {
@@ -85,7 +101,11 @@ export default function CardDetail({ cardId }: { cardId: string }) {
         headerComponent={<CardMetaInfo number={basicCardData.number} set={basicCardData.set} />}
       >
         <ScrollView showsVerticalScrollIndicator={false} style={styles.detailContent}>
-          <AddCardButton cardId={cardId} onQuantityChange={handleCollectionChange} />
+          <AddCardButton
+            cardId={cardId}
+            onQuantityChange={handleCollectionChange}
+            initialQuantity={basicCardData.occurrence}
+          />
           <TabSwitcher
             options={tabOptions}
             activeTabId={activeTab}

--- a/src/features/cards/types.ts
+++ b/src/features/cards/types.ts
@@ -28,6 +28,7 @@ export interface CardBase {
 export interface CardBasicInfo extends CardBase {
   imageLarge: string;
   number: string;
+  occurrence: number;
   set: {
     id: string;
     name: string;


### PR DESCRIPTION
## 📝 Description

Le AddCardButton ne reflect maintenant l'état réel de possession (on n’avait pas l’information par l’endpoint aupravant). De plus, les mutations API n'étaient actuellement pas optimisées selon les actions utilisateur (POST inutiles, on doit éviter les conflits 409 si on a déjà la card et qu’on revient à 1 dans le AddCardButton).

La logique du previousCardQuantity permet d'empêche les POST incorrects quand on fait 0→3→1 (ne doit pas re-POST à 1)

Related task : [FOL-114](https://sleeved.atlassian.net/browse/FOL-114)

## 📸 Screenshots / Demo

https://github.com/user-attachments/assets/1d1b476d-dd67-4607-b6e3-c354f34477b0

<!-- (Optional) Include screenshots, video, or a link to a live demo if applicable. -->

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-114]: https://sleeved.atlassian.net/browse/FOL-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ