### PR TITLE
Fol 116/display set cards occurences

### DIFF
--- a/src/features/cards/components/CardListDisplay.tsx
+++ b/src/features/cards/components/CardListDisplay.tsx
@@ -13,6 +13,7 @@ import { Card } from '../types';
 import { useRouter } from 'expo-router';
 import { useTheme } from '../../../theme/useTheme';
 import Badge from '../../../components/ui/Badge';
+import { Check } from 'lucide-react-native';
 
 interface CardListDisplayProps {
   cards: Card[];
@@ -75,6 +76,15 @@ export default function CardListDisplay({
           {item.occurrence && item.occurrence > 0 && (
             <View style={styles.occurenceBadge}>
               <Badge value={item.occurrence} />
+            </View>
+          )}
+          {item.isOwned && (
+            <View style={styles.occurenceBadge}>
+              <Check
+                size={20}
+                color={theme.colors.background.secondary}
+                style={{ backgroundColor: theme.colors.text.black, borderRadius: 12 }}
+              />
             </View>
           )}
         </View>

--- a/src/features/cards/types.ts
+++ b/src/features/cards/types.ts
@@ -4,6 +4,7 @@ export interface Card {
   imageLarge?: string;
   bestTrendPrice?: string;
   occurrence?: number;
+  isOwned?: boolean;
 }
 
 export interface CardsListResponse {

--- a/src/features/sets/components/SetListDisplay.tsx
+++ b/src/features/sets/components/SetListDisplay.tsx
@@ -26,17 +26,28 @@ export default function SetListDisplay({ set }: SetListDisplayProps) {
           router.push({ pathname: `/set/${set.id}` });
         }}
       >
-        <View style={styles.occurenceContainer}>
+        <View
+          style={[
+            styles.occurenceContainer,
+            {
+              width: SET_WIDTH,
+              height: SET_HEIGHT,
+              backgroundColor: theme.colors.background.secondary,
+              borderRadius: theme.borderRadius.medium,
+              ...theme.shadows.small,
+            },
+          ]}
+        >
           <Image
             source={{ uri: set.imageLogo }}
             resizeMethod="resize"
             resizeMode="contain"
-            style={{
-              width: SET_WIDTH,
-              height: SET_HEIGHT,
-              borderRadius: theme.borderRadius.medium,
-              ...theme.shadows.small,
-            }}
+            style={[
+              {
+                width: 100,
+                height: 100,
+              },
+            ]}
           />
           <View style={styles.symbolBadge}>
             <Image
@@ -52,7 +63,7 @@ export default function SetListDisplay({ set }: SetListDisplayProps) {
             />
           </View>
           <View style={styles.occurenceBadge}>
-            {set.nbOwned && set.nbOwned > 0 && <Text style={styles.badgeText}>{set.nbOwned}</Text>}
+            {set.nbOwned > 0 && <Text style={styles.badgeText}>{set.nbOwned}</Text>}
             <CircularProgressBar
               size={24}
               strokeWidth={6}
@@ -75,6 +86,8 @@ const styles = StyleSheet.create({
   },
   occurenceContainer: {
     position: 'relative',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   occurenceBadge: {
     position: 'absolute',


### PR DESCRIPTION
## 📝 Description

- Sets now have the number of cards that the user owns from it which is displayed.
- Sets details show if a card is owned by the user or not as well.


Related task : [FOL-116](https://sleeved.atlassian.net/browse/FOL-116)

## 📸 Screenshots / Demo
![Simulator Screenshot - iPhone 16 - 2025-07-08 at 15 07 47](https://github.com/user-attachments/assets/a8b6a83a-9d54-45fb-b1b2-5f4175910502)
![Simulator Screenshot - iPhone 16 - 2025-07-08 at 15 07 56](https://github.com/user-attachments/assets/00e54af5-da60-4b0b-bf10-3d5da9fc1f32)



## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-116]: https://sleeved.atlassian.net/browse/FOL-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ