### PR TITLE
feat(folio): folios list query & enhance folio management with new hooks and components

### DIFF
--- a/src/app/(tabs)/folios.tsx
+++ b/src/app/(tabs)/folios.tsx
@@ -4,17 +4,34 @@ import { useTheme } from '../../theme/useTheme';
 import { TabSwitcher } from '../../components/ui/TabSwitcher';
 import MyCardsScreen from '../../features/folio/screens/MyCardsScreen';
 import MyFoliosScreen from '../../features/folio/screens/MyFoliosScreen';
+import { useAllMyCards } from '../../features/folio/hooks/queries/useAllMyCards';
+import { LoadingState } from '../../components/ui/StatusIndicators';
+import EmptyStateCards from '../../features/folio/components/EmptyStateCards';
 
 type FolioTabType = 'cards' | 'folios';
+
+const tabOptions = [
+  { id: 'cards' as const, label: 'My Cards' },
+  { id: 'folios' as const, label: 'My Folios' },
+];
 
 export default function Folio() {
   const theme = useTheme();
   const [activeTab, setActiveTab] = useState<FolioTabType>('cards');
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useAllMyCards();
 
-  const tabOptions = [
-    { id: 'cards' as const, label: 'My Cards' },
-    { id: 'folios' as const, label: 'My Folios' },
-  ];
+  const myCardsDataFlatMap = data?.pages.flatMap((page) => page.data) ?? [];
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  console.log('myCardsData', data);
+
+  if (!isLoading && myCardsDataFlatMap?.length === 0) {
+    return <EmptyStateCards />;
+  }
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background.primary }]}>
@@ -25,7 +42,18 @@ export default function Folio() {
           onTabChange={(tabId) => setActiveTab(tabId)}
           containerStyle={styles.tabSwitcher}
         />
-        {activeTab === 'cards' ? <MyCardsScreen /> : <MyFoliosScreen />}
+        {activeTab === 'cards' ? (
+          <MyCardsScreen
+            myCardsData={myCardsDataFlatMap}
+            fetchNextPage={fetchNextPage}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            isLoading={isLoading}
+            error={error}
+          />
+        ) : (
+          <MyFoliosScreen />
+        )}
       </View>
     </View>
   );

--- a/src/components/ui/StatusIndicators.tsx
+++ b/src/components/ui/StatusIndicators.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { useTheme } from '../../theme/useTheme';
 
 interface ErrorStateProps {
-  message: string;
+  message?: string;
 }
 
 export function LoadingState() {
@@ -16,7 +16,7 @@ export function LoadingState() {
   );
 }
 
-export function ErrorState({ message }: ErrorStateProps) {
+export function ErrorState({ message = 'An error occurred' }: ErrorStateProps) {
   const theme = useTheme();
 
   return (

--- a/src/features/folio/components/FolioItem.tsx
+++ b/src/features/folio/components/FolioItem.tsx
@@ -57,7 +57,7 @@ export default function FolioItem({ folio, onPress }: FolioItemProps) {
       onPress={() => onPress && onPress(folio.id)}
     >
       <View style={[styles.iconContainer, { borderRadius: theme.borderRadius.small }]}>
-        <FolioIcon iconPath={folio.iconPath} size={80} />
+        <FolioIcon iconPath={folio.image} size={80} />
       </View>
 
       <View style={styles.contentContainer}>
@@ -72,9 +72,9 @@ export default function FolioItem({ folio, onPress }: FolioItemProps) {
         </Text>
 
         <View style={styles.statsContainer}>
-          <FolioItemStat label="Cards" value={folio.cardCount} />
-          <FolioItemStat label="Card Market" value={folio.cardMarketValue} />
-          <FolioItemStat label="TCG Player" value={folio.tcgPlayerValue} />
+          <FolioItemStat label="Cards" value={folio.statistics.totalCardsCount} />
+          <FolioItemStat label="Card Market" value={folio.statistics.cardMarketPrice} />
+          <FolioItemStat label="TCG Player" value={folio.statistics.tcgPlayerPrice} />
         </View>
       </View>
     </TouchableOpacity>

--- a/src/features/folio/components/FoliosList.tsx
+++ b/src/features/folio/components/FoliosList.tsx
@@ -5,14 +5,14 @@ import FolioItem from './FolioItem';
 import CreateFolioButton from './CreateFolioButton';
 
 interface FoliosListProps {
-  folios: FolioItemType[];
+  foliosData: FolioItemType[];
   onFolioPress?: (id: string) => void;
   onCreatePress: () => void;
   isLoading?: boolean;
 }
 
 export default function FoliosList({
-  folios,
+  foliosData,
   onFolioPress,
   onCreatePress,
   isLoading,
@@ -28,7 +28,7 @@ export default function FoliosList({
 
   return (
     <FlatList
-      data={folios}
+      data={foliosData}
       keyExtractor={(item) => item.id}
       renderItem={({ item }) => <FolioItem folio={item} onPress={onFolioPress} />}
       ListHeaderComponent={<CreateFolioButton onPress={onCreatePress} />}

--- a/src/features/folio/components/create/CreateFirstFolioCta.tsx
+++ b/src/features/folio/components/create/CreateFirstFolioCta.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+import { PlusCircle } from 'lucide-react-native';
+import { Button } from '../../../../components/ui';
+import { useTheme } from '../../../../theme/useTheme';
+import { useRouter } from 'expo-router';
+
+const CreateFirstFolioCta = () => {
+  const theme = useTheme();
+  const router = useRouter();
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.colors.background.primary }]}>
+      <PlusCircle size={80} color={theme.colors.primary} strokeWidth={1.5} />
+      <Text
+        style={[styles.title, { color: theme.colors.text.primary, marginTop: theme.spacing.xl }]}
+      >
+        Create your first folio!
+      </Text>
+      <Text
+        style={[
+          styles.description,
+          { color: theme.colors.text.secondary, marginBottom: theme.spacing.xl },
+        ]}
+      >
+        Organize your cards by creating a folio. You can add, edit, and manage your collection
+        easily.
+      </Text>
+      <Button
+        title="Create a folio"
+        variant="primary"
+        onPress={() => router.push('(folios)/create-folio')}
+        buttonStyle={styles.button}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 28,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  button: {
+    width: 220,
+  },
+});
+
+export default CreateFirstFolioCta;

--- a/src/features/folio/hooks/mutations/useCardFolioCollect.ts
+++ b/src/features/folio/hooks/mutations/useCardFolioCollect.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { httpClient } from '../../../../lib/client/http-client';
 import { useToaster } from '../../../../components/ui/ToasterProvider';
-import { folioKeys } from '../queries/useAllMyCards';
+import { folioCardsKeys } from '../queries/useAllMyCards';
 
 interface CollectPayload {
   cardId: string;
@@ -20,7 +20,7 @@ export const useCardFolioCollect = () => {
       return httpClient.post('/folios/cards', { cardId });
     },
     onSuccess: (response) => {
-      queryClient.invalidateQueries({ queryKey: folioKeys.allMyCards });
+      queryClient.invalidateQueries({ queryKey: folioCardsKeys.all });
       showToast({ message: response.message || 'Card added to your collection!', type: 'success' });
     },
     onError: (error) => {

--- a/src/features/folio/hooks/mutations/useCardFolioDelete.ts
+++ b/src/features/folio/hooks/mutations/useCardFolioDelete.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { httpClient } from '../../../../lib/client/http-client';
-import { folioKeys } from '../queries/useAllMyCards';
+import { folioCardsKeys } from '../queries/useAllMyCards';
+import { foliosKeys } from '../queries/useFolios';
+import { cardKeys } from '../../../cards/hooks/queries/useCardsQuery';
 import { useToaster } from '../../../../components/ui/ToasterProvider';
 
 interface DeleteCardPayload {
@@ -20,7 +22,10 @@ export const useCardFolioDelete = () => {
       return httpClient.delete<DeleteCardResponse>(`/folios/cards/${cardId}`);
     },
     onSuccess: (response) => {
-      queryClient.invalidateQueries({ queryKey: folioKeys.allMyCards });
+      queryClient.invalidateQueries({ queryKey: folioCardsKeys.all });
+      queryClient.invalidateQueries({ queryKey: foliosKeys.all });
+      queryClient.invalidateQueries({ queryKey: cardKeys.list('') });
+
       showToast({
         message: response.message || 'Card removed from your collection!',
         type: 'success',

--- a/src/features/folio/hooks/mutations/useCardFolioUpdate.ts
+++ b/src/features/folio/hooks/mutations/useCardFolioUpdate.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { httpClient } from '../../../../lib/client/http-client';
-import { folioKeys } from '../queries/useAllMyCards';
+import { folioCardsKeys } from '../queries/useAllMyCards';
 import { useToaster } from '../../../../components/ui/ToasterProvider';
 
 interface UpdateOccurrencePayload {
@@ -23,7 +23,7 @@ export const useCardFolioUpdate = () => {
       });
     },
     onSuccess: (response, variables) => {
-      queryClient.invalidateQueries({ queryKey: folioKeys.allMyCards });
+      queryClient.invalidateQueries({ queryKey: folioCardsKeys.all });
       showToast({
         message: `Card added x${variables.occurrence} to your collection!`,
         type: 'success',

--- a/src/features/folio/hooks/mutations/useCreateFolio.tsx
+++ b/src/features/folio/hooks/mutations/useCreateFolio.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { httpClient } from '../../../../lib/client/http-client';
-import { folioKeys } from '../queries/useAllMyCards';
+import { foliosKeys } from '../queries/useFolios';
 import { useToaster } from '../../../../components/ui/ToasterProvider';
 
 interface CreateFolioPayload {
@@ -25,7 +25,7 @@ export const useCreateFolio = () => {
       return httpClient.post<CreateFolioResponse>('/folios', payload);
     },
     onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({ queryKey: folioKeys.allMyCards });
+      queryClient.invalidateQueries({ queryKey: foliosKeys.all });
       showToast({
         message: `Folio "${variables.name}" created!`,
         type: 'success',

--- a/src/features/folio/hooks/queries/useAllMyCards.ts
+++ b/src/features/folio/hooks/queries/useAllMyCards.ts
@@ -4,13 +4,13 @@ import { CardsListResponse, Card } from '../../../cards/types';
 import { mapMyCardsApiToCards } from '../../mappers/myCardsMapper';
 import { MyCardsListResponse } from '../../types';
 
-export const folioKeys = {
-  allMyCards: ['folio', 'allMyCards'] as const,
+export const folioCardsKeys = {
+  all: ['folio', 'allMyCards'] as const,
 };
 
 export const useAllMyCards = () => {
   return useInfiniteQuery<{ data: Card[]; meta: CardsListResponse['meta'] }, Error>({
-    queryKey: folioKeys.allMyCards,
+    queryKey: folioCardsKeys.all,
     queryFn: async ({ pageParam = 1 }) => {
       const response = await httpClient.get<MyCardsListResponse>(
         `/folios/cards?page=${pageParam}&limit=30`

--- a/src/features/folio/hooks/queries/useFolios.ts
+++ b/src/features/folio/hooks/queries/useFolios.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { httpClient } from '../../../../lib/client/http-client';
+import { FolioItem } from '../../types';
+import { mapFolioList } from '../../mappers/folioListMapper';
+
+export const foliosKeys = {
+  all: ['folios'] as const,
+};
+
+export function useFolios() {
+  return useQuery<FolioItem[]>({
+    queryKey: foliosKeys.all,
+    queryFn: async () => {
+      const response = await httpClient.get<FolioItem[]>('/folios');
+      return mapFolioList(response);
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/features/folio/mappers/folioListMapper.ts
+++ b/src/features/folio/mappers/folioListMapper.ts
@@ -1,0 +1,13 @@
+import { FolioItem } from '../types';
+import { formatNumberShort } from '../../../lib/utils/number';
+
+export function mapFolioList(data: FolioItem[]): FolioItem[] {
+  return data.map((folio) => ({
+    ...folio,
+    statistics: {
+      ...folio.statistics,
+      cardMarketPrice: `${formatNumberShort(parseFloat(folio.statistics.cardMarketPrice))}€`,
+      tcgPlayerPrice: `$${formatNumberShort(parseFloat(folio.statistics.tcgPlayerPrice))}`,
+    },
+  }));
+}

--- a/src/features/folio/screens/CreateFolioScreen.tsx
+++ b/src/features/folio/screens/CreateFolioScreen.tsx
@@ -24,7 +24,7 @@ export default function CreateFolioScreen() {
   const handleSave = useCallback(() => {
     createFolio.mutate(
       {
-        imageUrl: '/assets/icons/icon-1.png',
+        imageUrl: 'https://res.cloudinary.com/dlgw148r2/image/upload/v1752003117/icon-1_qrqwwg.png',
         name,
         cards: [],
       },

--- a/src/features/folio/screens/MyCardsScreen.tsx
+++ b/src/features/folio/screens/MyCardsScreen.tsx
@@ -1,16 +1,27 @@
 import { View, StyleSheet } from 'react-native';
 import { useRefetchOnFocus } from '../../../hooks/useRefetchOnFocus';
-import EmptyStateCards from '../components/EmptyStateCards';
+import { Card } from '../../cards/types';
 import CardKPIStats from '../../cards/components/CardKPIStats';
 import CardListDisplay from '../../cards/components/CardListDisplay';
 import { useMainFolioStatistics } from '../hooks/queries/useMainFolioStatistics';
-import { useAllMyCards } from '../hooks/queries/useAllMyCards';
-import { LoadingState } from '../../../components/ui/StatusIndicators';
 
-export default function MyCardsScreen() {
-  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useAllMyCards();
+interface MyCardsScreenProps {
+  myCardsData: Card[];
+  fetchNextPage?: () => void;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  isLoading?: boolean;
+  error?: Error | null;
+}
 
+export default function MyCardsScreen({
+  myCardsData,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  isLoading,
+  error,
+}: MyCardsScreenProps) {
   const {
     data: myCardsStats,
     isLoading: isLoadingMyCardsStats,
@@ -23,20 +34,10 @@ export default function MyCardsScreen() {
   // and we want to ensure the data is up-to-date
   useRefetchOnFocus(refetchMyCardsStats);
 
-  const cardsData = data?.pages.flatMap((page) => page.data) ?? [];
-
-  if (isLoading) {
-    return <LoadingState />;
-  }
-
-  if (!isLoading && cardsData?.length === 0) {
-    return <EmptyStateCards />;
-  }
-
   return (
     <View style={styles.container}>
       <CardListDisplay
-        cards={cardsData}
+        cards={myCardsData}
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
         isLoading={isLoading}

--- a/src/features/folio/screens/MyFoliosScreen.tsx
+++ b/src/features/folio/screens/MyFoliosScreen.tsx
@@ -1,64 +1,41 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
-
 import { useTheme } from '../../../theme/useTheme';
-import EmptyStateCards from '../components/EmptyStateCards';
 import FoliosList from '../components/FoliosList';
-import { FolioItem } from '../types';
+import { useFolios } from '../hooks/queries/useFolios';
+import { ErrorState, LoadingState } from '../../../components/ui/StatusIndicators';
+import CreateFirstFolioCta from '../components/create/CreateFirstFolioCta';
 
 export default function MyFoliosScreen() {
   const theme = useTheme();
   const router = useRouter();
+  const { data: foliosListData, isLoading, error } = useFolios();
 
-  // Mock data to simulate fetched folios
-  const mockFolios: FolioItem[] = [
-    {
-      id: '1',
-      name: 'My Favorite Collection',
-      cardCount: 42,
-      cardMarketValue: '325.50€',
-      tcgPlayerValue: '$352.75',
-    },
-    {
-      id: '2',
-      name: 'Rare Cards',
-      cardCount: 12,
-      cardMarketValue: '678.25€',
-      tcgPlayerValue: '$712.99',
-    },
-    {
-      id: '3',
-      name: 'Starter Deck',
-      cardCount: 28,
-      cardMarketValue: '89.99€',
-      tcgPlayerValue: '$95.50',
-    },
-    {
-      id: '4',
-      name: 'Collection 2023',
-      cardCount: 63,
-      cardMarketValue: '425.30€',
-      tcgPlayerValue: '$450.10',
-    },
-  ];
+  if (isLoading) {
+    return (
+      <View style={styles.container}>
+        <LoadingState />
+      </View>
+    );
+  }
 
-  const hasCards = true;
+  if (!isLoading && error) {
+    return <ErrorState />;
+  }
 
-  const handleFolioPress = (id: string) => {
-    // @TODO: Implement navigation to folio details
-    console.log(`Folio pressed: ${id}`);
-  };
-
-  if (!hasCards) {
-    return <EmptyStateCards />;
+  if (!foliosListData || foliosListData.length === 0) {
+    return <CreateFirstFolioCta />;
   }
 
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background.primary }]}>
       <FoliosList
-        folios={mockFolios}
-        onFolioPress={handleFolioPress}
+        foliosData={foliosListData}
+        onFolioPress={(id) => {
+          /* TODO: navigation */
+          console.log('Folio pressed:', id);
+        }}
         onCreatePress={() => router.push('(folios)/create-folio')}
       />
     </View>

--- a/src/features/folio/types.ts
+++ b/src/features/folio/types.ts
@@ -3,10 +3,12 @@ import { Card, CardsListResponse } from '../cards/types';
 export interface FolioItem {
   id: string;
   name: string;
-  cardCount: number;
-  cardMarketValue: string;
-  tcgPlayerValue: string;
-  iconPath?: string;
+  image: string;
+  statistics: {
+    totalCardsCount: number;
+    cardMarketPrice: string;
+    tcgPlayerPrice: string;
+  };
 }
 
 export interface RawMyCard {


### PR DESCRIPTION
## 📝 Description

- Implemented `useFolios` hook for fetching folios data.
- Added `CreateFirstFolioCta` component for guiding users to create their first folio.
- Updated `FolioItem` and related components to support new data structure.
- Refactored `MyCardsScreen` and `MyFoliosScreen` to integrate new hooks and improve loading/error states.
- Improved loading and error handling in UI components.

Related task : [FOL-62](https://sleeved.atlassian.net/browse/FOL-62)

## 📸 Screenshots / Demo

![image](https://github.com/user-attachments/assets/9efe7128-b76d-41d0-b866-474dcb8f13fe)


## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-62]: https://sleeved.atlassian.net/browse/FOL-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ