### PR TITLE
feat(scan-other-results): enhance linear gradient with our colors theme

### DIFF
--- a/src/features/scan/screens/CardScanResult.tsx
+++ b/src/features/scan/screens/CardScanResult.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { SafeAreaView } from 'react-native-safe-area-context';
 import CardScanFail from '../components/CardScanFail';
 import CardScanSuccess from '../components/CardScanSuccess';
 import { Card } from '../../cards/types';
+import { useTheme } from '../../../theme/useTheme';
 
 interface CardScanResultProps {
   resultType: 'success' | 'fail';
@@ -17,16 +17,28 @@ export default function CardScanResult({
   cards,
   highlightedCardId,
 }: CardScanResultProps) {
+  const theme = useTheme();
+
   return (
-    <SafeAreaView style={styles.safeAreaView}>
-      <LinearGradient colors={['black', 'white']} style={styles.container} locations={[0.5, 0.8]}>
+    <View style={styles.safeAreaView}>
+      <LinearGradient
+        colors={[
+          theme.colors.primary,
+          theme.colors.background.secondary,
+          theme.colors.background.primary,
+        ]}
+        style={styles.container}
+        locations={[0, 0.6, 1]}
+        start={{ x: 0.5, y: 0 }}
+        end={{ x: 0.5, y: 1 }}
+      >
         {resultType === 'success' && cards ? (
           <CardScanSuccess cards={cards} highlightedCardId={highlightedCardId} />
         ) : (
           <CardScanFail />
         )}
       </LinearGradient>
-    </SafeAreaView>
+    </View>
   );
 }
 


### PR DESCRIPTION
## 📝 Description

Avant dans notre resultat du scan on avait un gradient noir et blanc. Mais maintenant on utilise plutôt notre theme.ts avec nos colors (notamment avec primary) pour avoir un meilleur rendu et + matcher avec notre theme

Related task : [FOL-119](https://sleeved.atlassian.net/browse/FOL-119)

## 📸 Screenshots / Demo

After:
![IMG_1689](https://github.com/user-attachments/assets/c7dd834b-7858-434c-84a5-faaacdc9a359)

Before:
![IMG_1688](https://github.com/user-attachments/assets/ab840468-6211-4811-adb5-dfcf6421441c)


## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-119]: https://sleeved.atlassian.net/browse/FOL-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ