### PR TITLE
fix(android-styles): rm shadow for images

### DIFF
--- a/src/features/cards/components/CardListDisplay.tsx
+++ b/src/features/cards/components/CardListDisplay.tsx
@@ -70,7 +70,6 @@ export default function CardListDisplay({
               width: CARD_WIDTH,
               height: CARD_HEIGHT,
               borderRadius: theme.borderRadius.medium,
-              ...theme.shadows.small,
             }}
           />
           {item.occurrence && item.occurrence > 0 && (

--- a/src/features/sets/components/SetListDisplay.tsx
+++ b/src/features/sets/components/SetListDisplay.tsx
@@ -58,7 +58,6 @@ export default function SetListDisplay({ set }: SetListDisplayProps) {
                 width: 32,
                 height: 32,
                 borderRadius: theme.borderRadius.medium,
-                ...theme.shadows.small,
               }}
             />
           </View>

--- a/src/features/sets/screens/SetDetail.tsx
+++ b/src/features/sets/screens/SetDetail.tsx
@@ -66,7 +66,6 @@ export default function SetDetail({ setId }: { setId: string }) {
               width: theme.spacing.xxl,
               height: theme.spacing.xxl,
               borderRadius: theme.borderRadius.medium,
-              ...theme.shadows.small,
             }}
           />
         </View>


### PR DESCRIPTION
## 📝 Description

On avait des shadows sur des images, elles ne se voient pas sur iOS, mais ça créer un visuel assez bizzare sur Android. Ça devrait résoudre le problème en les retirant.

Related task : [FOL-122](https://sleeved.atlassian.net/browse/FOL-122)

## 📸 Screenshots / Demo

<!-- (Optional) Include screenshots, video, or a link to a live demo if applicable. -->

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-122]: https://sleeved.atlassian.net/browse/FOL-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ