### PR TITLE
fix(folios): update tab titles to improve clarity

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -62,8 +62,8 @@ export default function TabLayout() {
       <Tabs.Screen
         name="folios"
         options={{
-          title: 'Folios',
-          headerTitle: () => <TabHeader title="Folios" />,
+          title: 'My collection',
+          headerTitle: () => <TabHeader title="My collection" />,
           tabBarIcon: ({ focused }) => (
             <Wallet
               color={focused ? theme.colors.text.primary : theme.colors.text.tertiary}

--- a/src/app/(tabs)/folios.tsx
+++ b/src/app/(tabs)/folios.tsx
@@ -11,8 +11,8 @@ import EmptyStateCards from '../../features/folio/components/EmptyStateCards';
 type FolioTabType = 'cards' | 'folios';
 
 const tabOptions = [
-  { id: 'cards' as const, label: 'My Cards' },
-  { id: 'folios' as const, label: 'My Folios' },
+  { id: 'cards' as const, label: 'My cards' },
+  { id: 'folios' as const, label: 'My folios' },
 ];
 
 export default function Folio() {


### PR DESCRIPTION
## 📝 Description

Par rapport au retour utilisateur sur le manque de clarté du wording de la tab "Folios", je pensais à plus "My collection" au final vu que dans cette page on a déjà les tabs "My cards" et "My folios"

Related task : [FOL-126](https://sleeved.atlassian.net/browse/FOL-126)

## 📸 Screenshots / Demo

![image](https://github.com/user-attachments/assets/526ed6c0-e371-4373-86eb-36000986246d)


## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-126]: https://sleeved.atlassian.net/browse/FOL-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ