### PR TITLE
fix(auth): update password validation rules in signup schema

### DIFF
--- a/src/features/auth/schemas/userSchema.ts
+++ b/src/features/auth/schemas/userSchema.ts
@@ -3,7 +3,14 @@ import { z } from 'zod';
 export const signupSchema = z
   .object({
     email: z.string().email('Invalid email').min(1, 'Email is required'),
-    password: z.string().min(6, 'Password must be at least 6 characters'),
+    password: z
+      .string()
+      .min(8, 'Password must be at least 8 characters')
+      .max(64, 'Password must be at most 64 characters')
+      .regex(
+        /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,64}$/,
+        'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character'
+      ),
     verifyPassword: z.string().min(1, 'Password confirmation is required'),
   })
   .refine((data) => data.password === data.verifyPassword, {


### PR DESCRIPTION
## 📝 Description

Modification du schema de validation zod pour avoir une validation de password un peu plus stricte : 
* 8 à 64 caractères
* Au moins une majuscule
* Au moins une minuscule
* Au moins un chiffre
* Au moins un caractère spécial

Lié à cette PR warden: [WAR-28/update-password-validation-rules](https://github.com/Sleeved-Project/warden/compare/WAR-28/update-password-validation-rules) pour que ce soit iso côté back

Related task : [FOL-136](https://sleeved.atlassian.net/browse/FOL-136)

## 📸 Screenshots / Demo

https://github.com/user-attachments/assets/a342fdb6-8a27-4e7e-b97c-9427873e673e

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-136]: https://sleeved.atlassian.net/browse/FOL-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ