### PR TITLE
fix(folio): rm success toast callbacks

### DIFF
--- a/src/features/folio/hooks/mutations/useCardFolioCollect.ts
+++ b/src/features/folio/hooks/mutations/useCardFolioCollect.ts
@@ -21,11 +21,10 @@ export const useCardFolioCollect = () => {
     mutationFn: async ({ cardId }: CollectPayload) => {
       return httpClient.post('/folios/cards', { cardId });
     },
-    onSuccess: (response) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: folioCardsKeys.all });
       queryClient.invalidateQueries({ queryKey: cardKeys.list('') });
       queryClient.invalidateQueries({ queryKey: setKeys.all });
-      showToast({ message: response.message || 'Card added to your collection!', type: 'success' });
     },
     onError: (error) => {
       showToast({ message: error.message || 'An error occured, please try later', type: 'error' });

--- a/src/features/folio/hooks/mutations/useCardFolioDelete.ts
+++ b/src/features/folio/hooks/mutations/useCardFolioDelete.ts
@@ -22,16 +22,11 @@ export const useCardFolioDelete = () => {
     mutationFn: async ({ cardId }) => {
       return httpClient.delete<DeleteCardResponse>(`/folios/cards/${cardId}`);
     },
-    onSuccess: (response) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: folioCardsKeys.all });
       queryClient.invalidateQueries({ queryKey: foliosKeys.all });
       queryClient.invalidateQueries({ queryKey: cardKeys.list('') });
       queryClient.invalidateQueries({ queryKey: setKeys.all });
-
-      showToast({
-        message: response.message || 'Card removed from your collection!',
-        type: 'success',
-      });
     },
     onError: (error) => {
       showToast({

--- a/src/features/folio/hooks/mutations/useCardFolioUpdate.ts
+++ b/src/features/folio/hooks/mutations/useCardFolioUpdate.ts
@@ -22,12 +22,8 @@ export const useCardFolioUpdate = () => {
         occurrence,
       });
     },
-    onSuccess: (response, variables) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: folioCardsKeys.all });
-      showToast({
-        message: `Card added x${variables.occurrence} to your collection!`,
-        type: 'success',
-      });
     },
     onError: (error) => {
       showToast({

--- a/src/features/folio/hooks/mutations/useCreateFolio.tsx
+++ b/src/features/folio/hooks/mutations/useCreateFolio.tsx
@@ -24,12 +24,8 @@ export const useCreateFolio = () => {
     mutationFn: async (payload) => {
       return httpClient.post<CreateFolioResponse>('/folios', payload);
     },
-    onSuccess: (_, variables) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: foliosKeys.all });
-      showToast({
-        message: `Folio "${variables.name}" created!`,
-        type: 'success',
-      });
     },
     onError: (error) => {
       showToast({


### PR DESCRIPTION
## 📝 Description

Le toast de success pour les retours utilisateurs à l’ajout de la collection prennent un peu trop de place, et cachent la tabs bar. Pour le moment nous avons pris la décision de les retirer (et garder uniquement les toast failed)

Related task : [FOL-148](https://sleeved.atlassian.net/browse/FOL-148)

## 📸 Screenshots / Demo

<!-- (Optional) Include screenshots, video, or a link to a live demo if applicable. -->

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-148]: https://sleeved.atlassian.net/browse/FOL-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ