### PR TITLE
fix(cards): set default active tab to prices in CardDetail component

### DIFF
--- a/src/features/cards/screens/CardDetail.tsx
+++ b/src/features/cards/screens/CardDetail.tsx
@@ -20,7 +20,7 @@ import { useRefetchOnFocus } from '../../../hooks/useRefetchOnFocus';
 type TabType = 'details' | 'prices';
 
 export default function CardDetail({ cardId }: { cardId: string }) {
-  const [activeTab, setActiveTab] = useState<TabType>('details');
+  const [activeTab, setActiveTab] = useState<TabType>('prices');
   const theme = useTheme();
   const { mutate: deleteCardFolio } = useCardFolioDelete();
   const { mutate: collectCard } = useCardFolioCollect();
@@ -45,8 +45,8 @@ export default function CardDetail({ cardId }: { cardId: string }) {
   useRefetchOnFocus(refetchCardDetail);
 
   const tabOptions: TabOption<TabType>[] = [
-    { id: 'details', label: 'Details' },
     { id: 'prices', label: 'Prices' },
+    { id: 'details', label: 'Details' },
   ];
 
   const handleCollectionChange = React.useCallback(


### PR DESCRIPTION
## 📝 Description

* Placer les prices en tab par défaut au niveau du détail d’une carte afin de les mettre plus en avant

Related task : [FOL-139](https://sleeved.atlassian.net/browse/FOL-139)

## 📸 Screenshots / Demo

<img width="2156" height="3772" alt="image" src="https://github.com/user-attachments/assets/b5868de6-a73a-45f4-b266-054d2375a261" />

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-139]: https://sleeved.atlassian.net/browse/FOL-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ