### PR TITLE
feat(auth): refresh token in authentication flow

### DIFF
--- a/src/features/auth/context/AuthContext.tsx
+++ b/src/features/auth/context/AuthContext.tsx
@@ -92,7 +92,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             await httpClient.get('/me', { apiType: 'auth' });
             setIsAuthenticated(true);
           } catch {
-            await authUtils.removeToken();
+            await authUtils.clearTokens();
             setIsAuthenticated(false);
           }
         } else {
@@ -124,9 +124,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       try {
         const response = await signinMutation({ email, password });
 
-        if (response && response.token) {
-          await authUtils.setToken(response.token);
+        if (response.token && response.refreshToken) {
+          // Store both tokens
+          await authUtils.setTokens({ token: response.token, refreshToken: response.refreshToken });
+
           setIsAuthenticated(true);
+
           // Update user data in query cache
           if (response.user) {
             queryClient.setQueryData(userKeys.currentUser(), response.user);
@@ -147,7 +150,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         throw err;
       }
     },
-    [signinMutation, queryClient]
+    [signinMutation, queryClient, router]
   );
 
   /**
@@ -166,8 +169,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         return { success: true, requiresVerification: true, email };
       }
 
-      if (response.token) {
-        await authUtils.setToken(response.token);
+      if (response.token && response.refreshToken) {
+        await authUtils.setTokens({ token: response.token, refreshToken: response.refreshToken });
+
         setIsAuthenticated(true);
       }
 
@@ -183,10 +187,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
    */
   const logout = async () => {
     try {
-      await authUtils.removeToken();
+      // Clear both access and refresh tokens
+      await authUtils.clearTokens();
+
       setIsAuthenticated(false);
       setError(null);
 
+      // Clear user data from cache
       queryClient.setQueryData(userKeys.currentUser(), null);
       queryClient.invalidateQueries({ queryKey: userProfileKeys.all });
       queryClient.removeQueries({ queryKey: userProfileKeys.all });

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -7,6 +7,7 @@ export interface User {
 
 export interface AuthResponse {
   token?: string;
+  refreshToken?: string;
   user: User;
   type?: string;
   requiresVerification?: boolean;

--- a/src/features/auth/utils/auth-utils.ts
+++ b/src/features/auth/utils/auth-utils.ts
@@ -1,6 +1,7 @@
 import { secureStorage } from '../../../lib/storage/secure-storage';
 
 export const TOKEN_KEY = 'auth_token';
+export const REFRESH_TOKEN_KEY = 'refresh_token';
 
 export const authUtils = {
   async getToken(): Promise<string | null> {
@@ -11,8 +12,30 @@ export const authUtils = {
     await secureStorage.setItemAsync(TOKEN_KEY, token);
   },
 
+  async getRefreshToken(): Promise<string | null> {
+    return await secureStorage.getItemAsync(REFRESH_TOKEN_KEY);
+  },
+
+  async setRefreshToken(refreshToken: string): Promise<void> {
+    await secureStorage.setItemAsync(REFRESH_TOKEN_KEY, refreshToken);
+  },
+
+  async setTokens({ token, refreshToken }: { token: string; refreshToken: string }): Promise<void> {
+    await this.setToken(token);
+    await this.setRefreshToken(refreshToken);
+  },
+
   async removeToken(): Promise<void> {
     await secureStorage.deleteItemAsync(TOKEN_KEY);
+  },
+
+  async removeRefreshToken(): Promise<void> {
+    await secureStorage.deleteItemAsync(REFRESH_TOKEN_KEY);
+  },
+
+  async clearTokens(): Promise<void> {
+    await this.removeToken();
+    await this.removeRefreshToken();
   },
 
   async isAuthenticated(): Promise<boolean> {

--- a/src/lib/client/http-client.ts
+++ b/src/lib/client/http-client.ts
@@ -1,8 +1,33 @@
 import { config } from '../../config';
-import { TOKEN_KEY } from '../../constants';
+import { authUtils, TOKEN_KEY } from '../../features/auth/utils/auth-utils';
 import { secureStorage } from '../storage/secure-storage';
-
 import { type FetchOptions, type ApiType, ApiError, ExtendedError } from './types';
+
+const NON_REFRESHABLE_ENDPOINTS = ['/refresh-token', '/login', '/register', '/signup'];
+
+// Queue for storing refresh token requests
+let isRefreshing = false;
+let refreshQueue: Array<{
+  resolve: (token: string) => void;
+  reject: (error: Error) => void;
+}> = [];
+
+// Process the refresh token queue
+const processQueue = (error: Error | null, newToken: string | null = null) => {
+  if (refreshQueue.length === 0) return;
+
+  if (error) {
+    refreshQueue.forEach((promise) => promise.reject(error));
+    refreshQueue = [];
+    return;
+  }
+
+  if (newToken) {
+    refreshQueue.forEach((promise) => promise.resolve(newToken));
+  }
+
+  refreshQueue = [];
+};
 
 const getApiBaseUrl = (apiType: ApiType = 'global'): string => {
   switch (apiType) {
@@ -10,10 +35,29 @@ const getApiBaseUrl = (apiType: ApiType = 'global'): string => {
       return config.API_WARDEN_BASE_URL;
     case 'global':
       return config.API_ATLAS_BASE_URL;
-    // add other URL API if needed here
     default:
       return config.API_ATLAS_BASE_URL;
   }
+};
+
+// Refresh the token with the stored refresh token
+const refreshToken = async (): Promise<string> => {
+  const refreshToken = await authUtils.getRefreshToken();
+  if (!refreshToken) throw new Error('Refresh token not available');
+
+  const response = await fetch(`${getApiBaseUrl('auth')}/refresh-token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  if (!response.ok) throw new Error('Failed to refresh token');
+
+  const data = await response.json();
+  await authUtils.setToken(data.token);
+  await authUtils.setRefreshToken(data.refreshToken);
+
+  return data.token;
 };
 
 const createHttpClient = () => {
@@ -21,74 +65,123 @@ const createHttpClient = () => {
     endpoint: string,
     { body, headers, responseType, apiType = 'global', ...options }: FetchOptions = {}
   ): Promise<T> => {
-    const defaultHeaders: Record<string, string> = {
-      'Content-Type': 'application/json',
+    const executeRequest = async (customToken?: string): Promise<T> => {
+      const defaultHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+
+      const token = customToken || (await secureStorage.getItemAsync(TOKEN_KEY));
+      if (token) {
+        defaultHeaders['Authorization'] = `Bearer ${token}`;
+      }
+
+      const isFormData = body instanceof FormData;
+      const finalHeaders = isFormData
+        ? { ...headers, ...(token ? { Authorization: `Bearer ${token}` } : {}) }
+        : { ...defaultHeaders, ...headers };
+
+      const baseUrl = getApiBaseUrl(apiType);
+      const response = await fetch(`${baseUrl}${endpoint}`, {
+        ...options,
+        headers: finalHeaders,
+        body: isFormData ? body : body ? JSON.stringify(body) : undefined,
+      });
+
+      if (!response.ok) {
+        try {
+          const contentType = response.headers.get('content-type');
+          if (contentType && contentType.includes('application/json')) {
+            const errorData = await response.json();
+
+            // Gestion of 401 errors - attempt to refresh the token
+            if (
+              response.status === 401 &&
+              !NON_REFRESHABLE_ENDPOINTS.some((nonRefreshableEndpoint) =>
+                endpoint.endsWith(nonRefreshableEndpoint)
+              )
+            ) {
+              // if already refreshing, add this request to the queue
+              if (isRefreshing) {
+                return new Promise<T>((resolve, reject) => {
+                  refreshQueue.push({
+                    resolve: (token) => {
+                      executeRequest(token).then(resolve).catch(reject);
+                    },
+                    reject,
+                  });
+                });
+              }
+
+              isRefreshing = true;
+
+              try {
+                // Attempt to refresh the token
+                const newToken = await refreshToken();
+                isRefreshing = false;
+
+                // Process the queue with the new token
+                processQueue(null, newToken);
+
+                // Retry the original request with the new token
+                return executeRequest(newToken);
+              } catch {
+                isRefreshing = false;
+
+                // Clear tokens and fail all pending requests
+                await authUtils.clearTokens();
+
+                // Notify all pending requests of the error
+                processQueue(new Error('Token refresh failed'));
+
+                // Trigger logout at the app level
+                throw new Error('Session expired. Please login again.');
+              }
+            }
+
+            // If the error data has a specific structure (e.g., code and message)
+            if (errorData.code && errorData.message) {
+              const apiError = new ApiError({
+                error: errorData.code,
+                message: errorData.message,
+              });
+
+              apiError.rawData = errorData;
+
+              throw apiError;
+            }
+
+            // If the error data has a different structure (e.g., error and message)
+            if (errorData.error && errorData.message) {
+              throw new ApiError(errorData);
+            }
+
+            // If the error data is not in the expected format, throw a generic error
+            const genericError = new Error(JSON.stringify(errorData)) as ExtendedError;
+            genericError.rawData = errorData;
+            throw genericError;
+          }
+
+          const errorMessage = await response.text();
+          throw new Error(errorMessage || `Request failed with status ${response.status}`);
+        } catch (error) {
+          if (error instanceof ApiError) {
+            throw error;
+          }
+
+          throw new Error(
+            error instanceof Error ? error.message : `Request failed with status ${response.status}`
+          );
+        }
+      }
+
+      if (responseType === 'blob') {
+        return response.blob() as Promise<T>;
+      }
+
+      return response.json();
     };
 
-    const token = await secureStorage.getItemAsync(TOKEN_KEY);
-    if (token) {
-      defaultHeaders['Authorization'] = `Bearer ${token}`;
-    }
-
-    const isFormData = body instanceof FormData;
-    const finalHeaders = isFormData
-      ? { ...headers, ...(token ? { Authorization: `Bearer ${token}` } : {}) }
-      : { ...defaultHeaders, ...headers };
-
-    const baseUrl = getApiBaseUrl(apiType);
-    const response = await fetch(`${baseUrl}${endpoint}`, {
-      ...options,
-      headers: finalHeaders,
-      body: isFormData ? body : body ? JSON.stringify(body) : undefined,
-    });
-
-    if (!response.ok) {
-      try {
-        const contentType = response.headers.get('content-type');
-        if (contentType && contentType.includes('application/json')) {
-          const errorData = await response.json();
-
-          // If the error data has a specific structure (e.g., code and message)
-          if (errorData.code && errorData.message) {
-            const apiError = new ApiError({
-              error: errorData.code,
-              message: errorData.message,
-            });
-
-            apiError.rawData = errorData;
-
-            throw apiError;
-          }
-
-          // If the error data has a different structure (e.g., error and message)
-          if (errorData.error && errorData.message) {
-            throw new ApiError(errorData);
-          }
-
-          // If the error data is not in the expected format, throw a generic error
-          const genericError = new Error(JSON.stringify(errorData)) as ExtendedError;
-          genericError.rawData = errorData;
-          throw genericError;
-        }
-
-        const errorMessage = await response.text();
-        throw new Error(errorMessage || `Request failed with status ${response.status}`);
-      } catch (error) {
-        if (error instanceof ApiError) {
-          throw error;
-        }
-
-        throw new Error(
-          error instanceof Error ? error.message : `Request failed with status ${response.status}`
-        );
-      }
-    }
-
-    if (responseType === 'blob') {
-      return response.blob() as Promise<T>;
-    }
-
-    return response.json();
+    return executeRequest();
   };
 
   return {


### PR DESCRIPTION
## 📝 Description

Implémentation côté front du flux de refresh token sûr et fiable : stocker le refresh token de façon sécurisée, rafraîchir access token automatiquement sur 401, re-essayer les requêtes en attente, et déconnecter l’utilisateur si refresh invalide

Related task : [FOL-209](https://sleeved.atlassian.net/browse/FOL-209)

## 📸 Screenshots / Demo

https://github.com/user-attachments/assets/7432bb6d-50eb-40b7-877b-a950b9048568

## ✅ Checklist

- [x] Code follows project standards (lint, format)
- [x] Performance optimization verified (if applicable)
- [x] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-209]: https://sleeved.atlassian.net/browse/FOL-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ