### PR TITLE
fix(cd-beta): update eas command for automated release message formatting

### DIFF
--- a/.github/workflows/cd-beta.yml
+++ b/.github/workflows/cd-beta.yml
@@ -31,4 +31,4 @@ jobs:
           EXPO_PUBLIC_API_ATLAS_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_ATLAS_BASE_URL }}
           EXPO_PUBLIC_API_WARDEN_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_WARDEN_BASE_URL }}
         run: |
-          eas update --branch release ${{ github.ref_name }} --message "Automated release with EAS Update"
+          eas update --branch=release --message="Release ${{ github.ref_name }}"


### PR DESCRIPTION
## 📝 Description

Le problème vient de la syntaxe de la commande eas update. L'erreur indique que "v1.1.3" est traité comme un argument inattendu car la CLI d'EAS interprète différemment les paramètres.

On essaye avec --branch=release uniquement

Related task : [FOL-217](https://sleeved.atlassian.net/browse/FOL-217)

## 📸 Screenshots / Demo

<!-- (Optional) Include screenshots, video, or a link to a live demo if applicable. -->

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-217]: https://sleeved.atlassian.net/browse/FOL-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ