### PR TITLE
fix(auth): set refresh token when email verification success

### DIFF
--- a/src/features/auth/hooks/mutations/useSignup.ts
+++ b/src/features/auth/hooks/mutations/useSignup.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { httpClient } from '../../../../lib/client/http-client';
-import { authUtils } from '../../utils/auth-utils';
 import type { AuthResponse, SignupPayload } from '../../types';
 import { userKeys } from '../queries/useCurrentUser';
 
@@ -12,11 +11,6 @@ export const useSignup = () => {
       const response = await httpClient.post<AuthResponse>('/register', userData, {
         apiType: 'auth',
       });
-
-      // Only set token if it exists (won't exist for unverified emails)
-      if (response.token) {
-        await authUtils.setToken(response.token);
-      }
 
       return response;
     },

--- a/src/features/auth/hooks/mutations/useVerifyEmailCode.ts
+++ b/src/features/auth/hooks/mutations/useVerifyEmailCode.ts
@@ -30,7 +30,7 @@ export const useVerifyEmailCode = () => {
       if (!response.token) {
         throw new Error('Verification failed: No token received');
       }
-      await authUtils.setToken(response.token);
+      await authUtils.setTokens({ token: response.token, refreshToken: response.refreshToken });
       setIsAuthenticated(true);
       setPendingVerificationEmail(null);
 

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -6,8 +6,8 @@ export interface User {
 }
 
 export interface AuthResponse {
-  token?: string;
-  refreshToken?: string;
+  token: string;
+  refreshToken: string;
   user: User;
   type?: string;
   requiresVerification?: boolean;


### PR DESCRIPTION
## 📝 Description

On fait en sorte ici de set le refresh token après la validation de mail en plus de set le token

Related task : [FOL-215](https://sleeved.atlassian.net/browse/FOL-215)

## 📸 Screenshots / Demo

<img width="1117" height="676" alt="image" src="https://github.com/user-attachments/assets/76f07f82-e1e9-4f2d-ab65-077cecf5c8c1" />


## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-215]: https://sleeved.atlassian.net/browse/FOL-215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ