### PR TITLE
FOL-268 : Fix currency with a card available offer mapper

### DIFF
--- a/src/features/cards/components/CardAvailableOfferItem.tsx
+++ b/src/features/cards/components/CardAvailableOfferItem.tsx
@@ -98,7 +98,7 @@ export default function CardAvailableOfferItem({
               },
             ]}
           >
-            ${originalPrice}
+            {originalPrice}
           </Text>
           <BadgeLabel label={condition.label} variant="dark" />
         </View>

--- a/src/features/cards/hooks/queries/useCardAvailableOffers.ts
+++ b/src/features/cards/hooks/queries/useCardAvailableOffers.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { httpClient } from '../../../../lib/client/http-client';
 import { cardKeys } from './useCardsQuery';
 import { CardAvailableOffersResponse } from '../../types';
+import { cardAvailableOffersMapper } from '../../mappers/cardAvailableOffersMapper';
 
 export const cardAvailableOffersKeys = {
   ads: (cardId: string) => [...cardKeys.all, 'ads', cardId] as const,
@@ -21,7 +22,7 @@ export function useCardAvailableOffers(cardId: string) {
       const response = await httpClient.get<CardAvailableOffersResponse>(
         `/cards/${cardId}/ads?${queryString}`
       );
-      return response;
+      return cardAvailableOffersMapper(response);
     },
     initialPageParam: 1,
     getNextPageParam: (lastPage, allPages) => {

--- a/src/features/cards/mappers/cardAvailableOffersMapper.ts
+++ b/src/features/cards/mappers/cardAvailableOffersMapper.ts
@@ -1,0 +1,13 @@
+import { CardAvailableOffersResponse } from '../types';
+
+export const cardAvailableOffersMapper = (
+  response: CardAvailableOffersResponse
+): CardAvailableOffersResponse => {
+  return {
+    ...response,
+    data: response.data.map((ad) => ({
+      ...ad,
+      originalPrice: ad.originalPrice + '€',
+    })),
+  };
+};

--- a/src/features/marketplace/components/CardForSaleItem.tsx
+++ b/src/features/marketplace/components/CardForSaleItem.tsx
@@ -76,7 +76,7 @@ export default function CardForSaleItem({ item }: AdItemProps) {
         <Text style={[{ color: theme.colors.text.secondary }]}>{item.seller.username}</Text>
 
         <Text style={{ fontWeight: theme.typography.fontWeights.bold, paddingTop: 2 }}>
-          ${item.originalPrice}
+          {item.originalPrice}
         </Text>
       </View>
     </Pressable>

--- a/src/features/marketplace/hooks/queries/useAdsList.ts
+++ b/src/features/marketplace/hooks/queries/useAdsList.ts
@@ -1,6 +1,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { httpClient } from '../../../../lib/client/http-client';
 import { AdsListResponse } from '../../types';
+import { mapAdList } from '../../mappers/adListMapper';
 
 export const adsKeys = {
   all: ['ads'] as const,
@@ -19,7 +20,7 @@ export const useAdsList = () => {
 
       const queryString = params.toString().replace(/%2C/g, ',');
       const response = await httpClient.get<AdsListResponse>(`/ads?${queryString}`);
-      return response;
+      return mapAdList(response);
     },
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.data.length === 0) return undefined;

--- a/src/features/marketplace/mappers/adListMapper.ts
+++ b/src/features/marketplace/mappers/adListMapper.ts
@@ -1,9 +1,9 @@
 import { Ad, AdsListResponse } from '../types';
 
-export const mapAdList = (data: AdsListResponse): AdsListResponse => {
+export const mapAdList = (response: AdsListResponse): AdsListResponse => {
   return {
-    ...data,
-    data: data.data.map((ad: Ad) => ({
+    ...response,
+    data: response.data.map((ad: Ad) => ({
       ...ad,
       originalPrice: ad.originalPrice + '€',
     })),

--- a/src/features/marketplace/mappers/adListMapper.ts
+++ b/src/features/marketplace/mappers/adListMapper.ts
@@ -1,0 +1,11 @@
+import { Ad, AdsListResponse } from '../types';
+
+export const mapAdList = (data: AdsListResponse): AdsListResponse => {
+  return {
+    ...data,
+    data: data.data.map((ad: Ad) => ({
+      ...ad,
+      originalPrice: ad.originalPrice + '€',
+    })),
+  };
+};


### PR DESCRIPTION
## 📝 Description

Petit refinement sur les annonces publiés d'une carte où le symbole EURO n'est plus inséré directement dans le front-end mais dans un mapper au moment du retour de la réponse API

Related task : [FOL-268](https://sleeved.atlassian.net/browse/FOL-268)

## 📸 Screenshots / Demo

<img width="864" height="1939" alt="Screenshot_20250918-170247" src="https://github.com/user-attachments/assets/7aa3736c-981d-434e-a9bc-a6b5b5177187" />


## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-268]: https://sleeved.atlassian.net/browse/FOL-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ