### PR TITLE
feat(ads): refetch on focus for UserAdList and CardAvailableOffers

### DIFF
--- a/src/features/cards/components/CardAvailableOffers.tsx
+++ b/src/features/cards/components/CardAvailableOffers.tsx
@@ -6,6 +6,7 @@ import TitleSection from '../../../components/ui/TitleSection';
 import { useTheme } from '../../../theme/useTheme';
 import { useCardAvailableOffers } from '../hooks/queries/useCardAvailableOffers';
 import CardAvailableOfferItem from './CardAvailableOfferItem';
+import { useRefetchOnFocus } from '../../../hooks/useRefetchOnFocus';
 
 interface CardAvailableOffersProps {
   title: string;
@@ -14,8 +15,17 @@ interface CardAvailableOffersProps {
 
 export default function CardAvailableOffers({ title, cardId }: CardAvailableOffersProps) {
   const theme = useTheme();
-  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useCardAvailableOffers(cardId);
+  const {
+    data,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch: refetchCardAvailableOffers,
+  } = useCardAvailableOffers(cardId);
+
+  useRefetchOnFocus(refetchCardAvailableOffers);
 
   const availableOffers = useMemo(() => {
     return data?.pages.flatMap((page) => page.data) || [];

--- a/src/features/user/components/profile/UserAdList.tsx
+++ b/src/features/user/components/profile/UserAdList.tsx
@@ -6,6 +6,7 @@ import { useUserAds } from '../../hooks/queries/useUserInfo';
 import TitleSection from '../../../../components/ui/TitleSection';
 import { useTheme } from '../../../../theme/useTheme';
 import { Ad } from '../../../marketplace/types';
+import { useRefetchOnFocus } from '../../../../hooks/useRefetchOnFocus';
 
 interface UserAdListProps {
   userId: string;
@@ -13,7 +14,10 @@ interface UserAdListProps {
 }
 
 export default function UserAdList({ userId, contentContainerStyle }: UserAdListProps) {
-  const { data: ads, isLoading, error } = useUserAds(userId);
+  const { data: ads, isLoading, error, refetch: refetchUserAds } = useUserAds(userId);
+
+  useRefetchOnFocus(refetchUserAds);
+
   const adsListFlat = ads?.pages.flatMap((page) => page.data) ?? ([] as Ad[]);
   const theme = useTheme();
 

--- a/src/features/user/hooks/queries/useUserInfo.ts
+++ b/src/features/user/hooks/queries/useUserInfo.ts
@@ -27,7 +27,9 @@ export function useUserProfile(userId?: string) {
       const response = await httpClient.get<UserProfileData>(uri);
       return response;
     },
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
+    refetchOnMount: 'always',
+    retry: false,
   });
 }
 


### PR DESCRIPTION
## 📝 Description

Pour tout ce qui est relatif aux ads, on souhaite que les données soient les plus fraiches possibles. Sauf qu'au vu de notre utilisation de tanstack pour le cache de queries, les queries ne se refaisait pas quand on se re-rendait sur la page en question. Pour fixer ça, on utilise notre custom hook `useRefetchOnFocus` (pas de possibilité de faire avec un `refetchOnMount: 'always'` traditionnel puisque ce qui est dans la tabs est déjà monté)

Related task : [FOL-267](https://sleeved.atlassian.net/browse/FOL-267)

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-267]: https://sleeved.atlassian.net/browse/FOL-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ