### PR TITLE
feat(ad-detail): add buyer information display for sold ads

### DIFF
--- a/src/features/marketplace/components/AdBuyerCard.tsx
+++ b/src/features/marketplace/components/AdBuyerCard.tsx
@@ -1,0 +1,47 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '../../../theme/useTheme';
+import ProfilePicture from '../../user/components/profile/ProfilePicture';
+import { useAdBuyer } from '../../user/hooks/queries/useAdBuyer';
+import { LoadingState, ErrorState } from '../../../components/ui/StatusIndicators';
+
+interface AdBuyerCardProps {
+  adId: string;
+  style?: object;
+}
+
+export default function AdBuyerCard({ adId, style }: AdBuyerCardProps) {
+  const theme = useTheme();
+  const { data: buyer, isLoading, error } = useAdBuyer(adId);
+  console.log('buyer:', buyer);
+
+  if (isLoading) return <LoadingState />;
+  if (error || !buyer) return <ErrorState message="Failed to load buyer info." />;
+
+  return (
+    <View style={[styles.container, style]}>
+      <ProfilePicture username={buyer.username} uri={buyer.profilePictureUrl} size="small" />
+      <View style={styles.info}>
+        <Text
+          style={{
+            color: theme.colors.text.primary,
+            fontSize: theme.typography.fontSizes.md,
+            fontWeight: theme.typography.fontWeights.bold,
+            paddingLeft: 10,
+          }}
+        >
+          {buyer.username}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  info: {
+    flex: 1,
+  },
+});

--- a/src/features/marketplace/hooks/queries/useAdsList.ts
+++ b/src/features/marketplace/hooks/queries/useAdsList.ts
@@ -7,6 +7,7 @@ export const adsKeys = {
   all: ['ads'] as const,
   getAdById: (id: string) => [...adsKeys.all, 'ad', id] as const,
   searchAds: (query: string) => [...adsKeys.all, 'searchAds', { query }] as const,
+  getBuyerByAdId: (id: string) => [...adsKeys.all, 'buyer', id] as const,
 };
 
 export const useAdsList = () => {

--- a/src/features/marketplace/screens/AdDetailScreen.tsx
+++ b/src/features/marketplace/screens/AdDetailScreen.tsx
@@ -9,6 +9,8 @@ import { useAdDetail } from '../hooks/queries/useAdDetail';
 import CertificationBadge from '../components/CertificationBadge';
 import { AdStatusEnum } from '../types';
 import { useAuth } from '../../auth/context/AuthContext';
+import TitleSection from '../../../components/ui/TitleSection';
+import AdBuyerCard from '../components/AdBuyerCard';
 
 export default function AdDetailScreen({ adId }: { adId: string }) {
   const theme = useTheme();
@@ -30,6 +32,9 @@ export default function AdDetailScreen({ adId }: { adId: string }) {
   if (isLoading) return <LoadingState />;
   if (error || !ad) return <ErrorState message="Failed to load ad details." />;
 
+  const shouldShowBuyerInfo = ad.status.label === AdStatusEnum.SOLD && user?.id === ad.seller.id;
+  const canBuy = ad.status.label === AdStatusEnum.PUBLISHED && user?.id !== ad.seller.id;
+
   return (
     <>
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.container}>
@@ -38,9 +43,16 @@ export default function AdDetailScreen({ adId }: { adId: string }) {
           imageVerso={ad.versoImageUrl}
           title={ad.card.name}
         />
+
         <AdSellerCard seller={ad.seller} onPress={handleSeller} />
-        <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: theme.colors.text.black }]}>
+
+        <View
+          style={[
+            { paddingHorizontal: theme.spacing.md, marginTop: theme.spacing.md },
+            styles.section,
+          ]}
+        >
+          <Text style={[styles.sectionTitle, { color: theme.colors.primaryForeground }]}>
             {ad.card.name}
           </Text>
           <Text
@@ -56,6 +68,18 @@ export default function AdDetailScreen({ adId }: { adId: string }) {
 
         {ad.certificate && <CertificationBadge certification={ad.certificate} />}
 
+        {shouldShowBuyerInfo && (
+          <View
+            style={[
+              { paddingHorizontal: theme.spacing.md, marginTop: theme.spacing.sm },
+              styles.section,
+            ]}
+          >
+            <TitleSection title="Buyer information" />
+            <AdBuyerCard adId={ad.id} style={{ paddingBottom: theme.spacing.xl }} />
+          </View>
+        )}
+
         {/* <View style={styles.section}>
           <CardAvailableOffers cardId={ad.id} title="Other selling" />
         </View> */}
@@ -65,7 +89,7 @@ export default function AdDetailScreen({ adId }: { adId: string }) {
         ad={ad}
         onSeeCardDetail={handleSeeCardDetail}
         onBuy={handleBuy}
-        canBuy={Boolean(ad.status.label === AdStatusEnum.PUBLISHED && user?.id !== ad.seller.id)}
+        canBuy={canBuy}
       />
     </>
   );
@@ -76,9 +100,7 @@ const styles = StyleSheet.create({
     paddingBottom: 100,
   },
   section: {
-    marginHorizontal: 16,
     gap: 4,
-    marginTop: 16,
   },
   sectionTitle: {
     fontSize: 20,

--- a/src/features/user/hooks/queries/useAdBuyer.ts
+++ b/src/features/user/hooks/queries/useAdBuyer.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { httpClient } from '../../../../lib/client/http-client';
+import { adsKeys } from '../../../marketplace/hooks/queries/useAdsList';
+
+export interface AdBuyerInformation {
+  username: string;
+  profilePictureUrl: string;
+}
+
+export const useAdBuyer = (adId: string) => {
+  return useQuery({
+    queryKey: adsKeys.getBuyerByAdId(adId),
+    queryFn: async () => {
+      const response = await httpClient.get<AdBuyerInformation>(`/me/ads/${adId}/buyer`);
+      return response;
+    },
+    enabled: !!adId,
+    retry: false,
+    staleTime: 0,
+    refetchOnMount: 'always',
+  });
+};


### PR DESCRIPTION
## 📝 Description

Afficher et faire la query vers les détails du buyer pour une offre acheté (uniquement si cette offre appartient au current user)

Related task : [FOL-283](https://sleeved.atlassian.net/browse/FOL-283)

## 📸 Screenshots / Demo

<img width="1170" height="2532" alt="IMG_3538" src="https://github.com/user-attachments/assets/a845c0ca-e50f-43f9-8efa-dcba35d59af0" />


## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[FOL-283]: https://sleeved.atlassian.net/browse/FOL-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ